### PR TITLE
Fix Version Requirement

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,6 +14,9 @@
   "accessWidener": "fabricforwarding.accesswidener",
   "depends": {
     "fabricloader": ">=0.7.8+build.187",
-    "minecraft": "1.15.2"
+    "minecraft": [
+      "1.16.2",
+      "1.16.3"
+    ]
   }
 }


### PR DESCRIPTION
The 2.0.0+1.16.2 release crashes on startup because the Minecraft version requirement wasn't changed. Although the mod was technically only updated to support 1.16.2, 1.16.3 was an extremely small update that virtually every mod works without issue. I have been using Fabric Forwarding (with this change) on 1.16.3 without issue for several weeks.